### PR TITLE
fix: localhost:6969 now working

### DIFF
--- a/terrainapp/backend/package.json
+++ b/terrainapp/backend/package.json
@@ -2,7 +2,6 @@
   "name": "terrainapp",
   "private": true,
   "version": "0.0.0",
-  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
@@ -12,6 +11,7 @@
   },
   "dependencies": {
     "express": "^5.1.0",
+    "cors": "^2.8.5",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.6.3",


### PR DESCRIPTION
### Related Ticket
* [Link to the Trello ticket](https://trello.com/c/bxg0e8vH/63-localhost6969-api-not-working)

### Description
This pull request resolves a backend connectivity issue where API requests to `localhost:6969/api` were failing due to missing Cross-Origin Resource Sharing (CORS) configuration.  
The root cause was the absence of the `cors` dependency in `package.json`, preventing the server from handling requests originating from the frontend during local development.  

### Changes Made
- **Feature/Major Change:**  
  - None (no new features introduced).  
- **Bug Fix/Minor Change:**  
  - Added the `cors` dependency to `package.json`.  
  - Configured CORS middleware in the backend to allow requests from the frontend during local development.  
